### PR TITLE
refactor: use builder pattern in `Resolver`'s constructor

### DIFF
--- a/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -4,7 +4,7 @@ use dns_test::client::{Client, DigSettings};
 use dns_test::name_server::NameServer;
 use dns_test::record::{Record, RecordType};
 use dns_test::zone_file::Root;
-use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
+use dns_test::{Network, Resolver, Result, FQDN};
 
 #[test]
 fn can_resolve() -> Result<()> {
@@ -39,8 +39,11 @@ fn can_resolve() -> Result<()> {
 
     eprintln!("root.zone:\n{}", root_ns.zone_file());
 
-    let roots = &[Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr())];
-    let resolver = Resolver::start(&dns_test::subject(), roots, &TrustAnchor::empty(), &network)?;
+    let resolver = Resolver::new(
+        &network,
+        Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr()),
+    )
+    .start(&dns_test::subject())?;
     let resolver_ip_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;
@@ -85,8 +88,11 @@ fn nxdomain() -> Result<()> {
     root_ns.referral(FQDN::COM, com_ns.fqdn().clone(), com_ns.ipv4_addr());
     let root_ns = root_ns.start()?;
 
-    let roots = &[Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr())];
-    let resolver = Resolver::start(&dns_test::subject(), roots, &TrustAnchor::empty(), &network)?;
+    let resolver = Resolver::new(
+        &network,
+        Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr()),
+    )
+    .start(&dns_test::subject())?;
     let resolver_ip_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
@@ -3,19 +3,15 @@ use dns_test::name_server::NameServer;
 use dns_test::record::RecordType;
 use dns_test::tshark::{Capture, Direction};
 use dns_test::zone_file::Root;
-use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
+use dns_test::{Network, Resolver, Result, FQDN};
 
 #[test]
 #[ignore]
 fn edns_support() -> Result<()> {
     let network = &Network::new()?;
     let ns = NameServer::new(&dns_test::peer(), FQDN::ROOT, network)?.start()?;
-    let resolver = Resolver::start(
-        &dns_test::subject(),
-        &[Root::new(ns.fqdn().clone(), ns.ipv4_addr())],
-        &TrustAnchor::empty(),
-        network,
-    )?;
+    let resolver = Resolver::new(network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
+        .start(&dns_test::subject())?;
 
     let mut tshark = resolver.eavesdrop()?;
 

--- a/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -5,7 +5,7 @@ use dns_test::client::{Client, DigSettings};
 use dns_test::name_server::NameServer;
 use dns_test::record::{Record, RecordType};
 use dns_test::zone_file::Root;
-use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
+use dns_test::{Network, Resolver, Result, FQDN};
 
 #[ignore]
 #[test]
@@ -64,10 +64,13 @@ fn bad_signature_in_leaf_nameserver() -> Result<()> {
 
     let root_ns = root_ns.start()?;
 
-    let roots = &[Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr())];
-
-    let trust_anchor = TrustAnchor::from_iter([root_ksk.clone(), root_zsk.clone()]);
-    let resolver = Resolver::start(&dns_test::subject(), roots, &trust_anchor, &network)?;
+    let resolver = Resolver::new(
+        &network,
+        Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr()),
+    )
+    .trust_anchor_key(root_ksk)
+    .trust_anchor_key(root_zsk)
+    .start(&dns_test::subject())?;
     let resolver_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/packages/dns-test/examples/explore.rs
+++ b/packages/dns-test/examples/explore.rs
@@ -44,13 +44,16 @@ fn main() -> Result<()> {
     let root_zsk = root_ns.zone_signing_key().clone();
 
     let root_ns = root_ns.start()?;
-
-    let roots = &[Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr())];
     println!("DONE");
 
     let trust_anchor = TrustAnchor::from_iter([root_ksk.clone(), root_zsk.clone()]);
     println!("building docker image...");
-    let resolver = Resolver::start(&dns_test::subject(), roots, &trust_anchor, &network)?;
+    let resolver = Resolver::new(
+        &network,
+        Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr()),
+    )
+    .trust_anchor(&trust_anchor)
+    .start(&dns_test::subject())?;
     println!("DONE\n\n");
 
     let resolver_addr = resolver.ipv4_addr();

--- a/packages/dns-test/src/trust_anchor.rs
+++ b/packages/dns-test/src/trust_anchor.rs
@@ -20,6 +20,10 @@ impl TrustAnchor {
         self
     }
 
+    pub(crate) fn keys(&self) -> &[DNSKEY] {
+        &self.keys
+    }
+
     /// formats the `TrustAnchor` in the format `delv` expects
     pub(super) fn delv(&self) -> String {
         let mut buf = "trust-anchors {".to_string();

--- a/packages/dns-test/src/tshark.rs
+++ b/packages/dns-test/src/tshark.rs
@@ -248,7 +248,7 @@ mod tests {
     use crate::name_server::NameServer;
     use crate::record::{Record, RecordType};
     use crate::zone_file::Root;
-    use crate::{Implementation, Network, Resolver, TrustAnchor, FQDN};
+    use crate::{Implementation, Network, Resolver, FQDN};
 
     use super::*;
 
@@ -310,13 +310,11 @@ mod tests {
         root_ns.referral(FQDN::COM, com_ns.fqdn().clone(), com_ns.ipv4_addr());
         let root_ns = root_ns.start()?;
 
-        let roots = &[Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr())];
-        let resolver = Resolver::start(
-            &Implementation::Unbound,
-            roots,
-            &TrustAnchor::empty(),
+        let resolver = Resolver::new(
             network,
-        )?;
+            Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr()),
+        )
+        .start(&Implementation::Unbound)?;
         let mut tshark = resolver.eavesdrop()?;
         let resolver_addr = resolver.ipv4_addr();
 


### PR DESCRIPTION
the `start` constructor's parameter list was getting long and we want to add even more configuration options, like EDE, in the future.

using the builder pattern lets us introduce new settings without breaking changes

:warning:  **NOTE**: this PR depends on #29 so it's base branch has been set to that PR's branch. switch the base to `main` before merging this