### PR TITLE
turn `dns_test::{subject,peer}` into immutable statics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ name = "dns-test"
 version = "0.1.0"
 dependencies = [
  "ctrlc",
+ "lazy_static",
  "minijinja",
  "pretty_assertions",
  "serde",
@@ -294,6 +295,12 @@ checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/packages/conformance-tests/src/name_server/rfc4035/section_3/section_3_1/section_3_1_1.rs
+++ b/packages/conformance-tests/src/name_server/rfc4035/section_3/section_3_1/section_3_1_1.rs
@@ -8,7 +8,7 @@ use dns_test::{Network, Result, FQDN};
 fn rrsig_in_answer_section() -> Result<()> {
     let network = Network::new()?;
 
-    let ns = NameServer::new(&dns_test::subject(), FQDN::ROOT, &network)?
+    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, &network)?
         .sign()?
         .start()?;
 
@@ -37,7 +37,7 @@ fn rrsig_in_answer_section() -> Result<()> {
 fn rrsig_in_authority_section() -> Result<()> {
     let network = Network::new()?;
 
-    let ns = NameServer::new(&dns_test::subject(), FQDN::ROOT, &network)?
+    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, &network)?
         .sign()?
         .start()?;
 

--- a/packages/conformance-tests/src/name_server/scenarios.rs
+++ b/packages/conformance-tests/src/name_server/scenarios.rs
@@ -6,7 +6,7 @@ use dns_test::{Network, Result, FQDN};
 #[test]
 fn authoritative_answer() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(&dns_test::subject(), FQDN::ROOT, network)?.start()?;
+    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, network)?.start()?;
 
     let client = Client::new(network)?;
     let ans = client.dig(

--- a/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -11,9 +11,8 @@ fn can_resolve() -> Result<()> {
     let needle_fqdn = FQDN("example.nameservers.com.")?;
 
     let network = Network::new()?;
-    let peer = dns_test::peer();
 
-    let mut leaf_ns = NameServer::new(&peer, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {
@@ -22,7 +21,7 @@ fn can_resolve() -> Result<()> {
         ..
     } = Graph::build(leaf_ns, Sign::No)?;
 
-    let resolver = Resolver::new(&network, root).start(&dns_test::subject())?;
+    let resolver = Resolver::new(&network, root).start(&dns_test::SUBJECT)?;
     let resolver_ip_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;
@@ -47,9 +46,8 @@ fn nxdomain() -> Result<()> {
     let needle_fqdn = FQDN("unicorn.nameservers.com.")?;
 
     let network = Network::new()?;
-    let peer = dns_test::peer();
 
-    let leaf_ns = NameServer::new(&peer, FQDN::NAMESERVERS, &network)?;
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
 
     let Graph {
         nameservers: _nameservers,
@@ -57,7 +55,7 @@ fn nxdomain() -> Result<()> {
         ..
     } = Graph::build(leaf_ns, Sign::No)?;
 
-    let resolver = Resolver::new(&network, root).start(&dns_test::subject())?;
+    let resolver = Resolver::new(&network, root).start(&dns_test::SUBJECT)?;
     let resolver_ip_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
@@ -9,9 +9,9 @@ use dns_test::{Network, Resolver, Result, FQDN};
 #[ignore]
 fn edns_support() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(&dns_test::peer(), FQDN::ROOT, network)?.start()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.start()?;
     let resolver = Resolver::new(network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-        .start(&dns_test::subject())?;
+        .start(&dns_test::SUBJECT)?;
 
     let mut tshark = resolver.eavesdrop()?;
 

--- a/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -13,9 +13,8 @@ fn bad_signature_in_leaf_nameserver() -> Result<()> {
     let needle_fqdn = FQDN("example.nameservers.com.")?;
 
     let network = Network::new()?;
-    let peer = dns_test::peer();
 
-    let mut leaf_ns = NameServer::new(&peer, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {
@@ -48,7 +47,7 @@ fn bad_signature_in_leaf_nameserver() -> Result<()> {
     let trust_anchor = &trust_anchor.unwrap();
     let resolver = Resolver::new(&network, root)
         .trust_anchor(trust_anchor)
-        .start(&dns_test::subject())?;
+        .start(&dns_test::SUBJECT)?;
     let resolver_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -125,14 +125,14 @@ fn fixture(
     expected: ExtendedDnsError,
     amend: fn(needle_fqdn: &FQDN, zone: &FQDN, records: &mut Vec<Record>),
 ) -> Result<()> {
-    let subject = dns_test::subject();
+    let subject = &dns_test::SUBJECT;
     let supports_ede = subject.supports_ede();
 
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
     let needle_fqdn = FQDN("example.nameservers.com.")?;
 
     let network = Network::new()?;
-    let mut leaf_ns = NameServer::new(&dns_test::peer(), FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {
@@ -153,7 +153,7 @@ fn fixture(
     }
 
     let trust_anchor = &trust_anchor.unwrap();
-    let resolver = resolver.trust_anchor(trust_anchor).start(&subject)?;
+    let resolver = resolver.trust_anchor(trust_anchor).start(subject)?;
     let resolver_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -11,7 +11,7 @@ use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 #[test]
 fn can_validate_without_delegation() -> Result<()> {
     let network = Network::new()?;
-    let mut ns = NameServer::new(&dns_test::peer(), FQDN::ROOT, &network)?;
+    let mut ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, &network)?;
     ns.add(Record::a(ns.fqdn().clone(), ns.ipv4_addr()));
     let ns = ns.sign()?;
 
@@ -27,7 +27,7 @@ fn can_validate_without_delegation() -> Result<()> {
     let trust_anchor = &TrustAnchor::from_iter([root_ksk.clone(), root_zsk.clone()]);
     let resolver = Resolver::new(&network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
         .trust_anchor(trust_anchor)
-        .start(&dns_test::subject())?;
+        .start(&dns_test::SUBJECT)?;
     let resolver_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;
@@ -49,10 +49,9 @@ fn can_validate_with_delegation() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
     let needle_fqdn = FQDN("example.nameservers.com.")?;
 
-    let peer = dns_test::peer();
     let network = Network::new()?;
 
-    let mut leaf_ns = NameServer::new(&peer, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {
@@ -64,7 +63,7 @@ fn can_validate_with_delegation() -> Result<()> {
     let trust_anchor = &trust_anchor.unwrap();
     let resolver = Resolver::new(&network, root)
         .trust_anchor(trust_anchor)
-        .start(&dns_test::subject())?;
+        .start(&dns_test::SUBJECT)?;
     let resolver_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/packages/dns-test/Cargo.toml
+++ b/packages/dns-test/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
+lazy_static = "1.4.0"
 minijinja = "1.0.12"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"

--- a/packages/dns-test/examples/explore.rs
+++ b/packages/dns-test/examples/explore.rs
@@ -8,16 +8,16 @@ use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 
 fn main() -> Result<()> {
     let network = Network::new()?;
-    let peer = dns_test::peer();
+    let peer = &dns_test::PEER;
 
     println!("building docker image...");
-    let mut root_ns = NameServer::new(&peer, FQDN::ROOT, &network)?;
+    let mut root_ns = NameServer::new(peer, FQDN::ROOT, &network)?;
     println!("DONE");
 
     println!("setting up name servers...");
-    let mut com_ns = NameServer::new(&peer, FQDN::COM, &network)?;
+    let mut com_ns = NameServer::new(peer, FQDN::COM, &network)?;
 
-    let mut nameservers_ns = NameServer::new(&peer, FQDN("nameservers.com.")?, &network)?;
+    let mut nameservers_ns = NameServer::new(peer, FQDN("nameservers.com.")?, &network)?;
     nameservers_ns
         .add(Record::a(root_ns.fqdn().clone(), root_ns.ipv4_addr()))
         .add(Record::a(com_ns.fqdn().clone(), com_ns.ipv4_addr()));
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
         Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr()),
     )
     .trust_anchor(&trust_anchor)
-    .start(&dns_test::subject())?;
+    .start(&dns_test::SUBJECT)?;
     println!("DONE\n\n");
 
     let resolver_addr = resolver.ipv4_addr();

--- a/packages/dns-test/src/implementation.rs
+++ b/packages/dns-test/src/implementation.rs
@@ -34,7 +34,7 @@ pub enum Role {
     Resolver,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Implementation {
     Bind,
     Hickory(Repository<'static>),
@@ -178,7 +178,7 @@ impl fmt::Display for Implementation {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Repository<'a> {
     inner: Cow<'a, str>,
 }


### PR DESCRIPTION
using `std::env::set_var` to set or change the value of either DNS_TEST_SUBJECT or DNS_TEST_PEER  is A Bad Idea, specially so when tests  are running in parallel

we can't forbid the use of `env::set_var` _but_ at least we can ensure that even in its presence the return value of `dns_test::{subject,peer}` will not change

this is accomplished using a "lazy" static variable that gets initialized at most once during the lifetime of the process instead of reading the env var each time `{subject,peer}` is called

to better convey the fact that the return value of `{subject,peer}` won't change, we present them as static variables instead