### PR TITLE
shoehorn hickory's on-the-fly signing into the NameServer<Signed> API 

### DIFF
--- a/packages/conformance-tests/src/name_server/rfc4035/section_3/section_3_1/section_3_1_1.rs
+++ b/packages/conformance-tests/src/name_server/rfc4035/section_3/section_3_1/section_3_1_1.rs
@@ -4,7 +4,6 @@ use dns_test::record::{Record, RecordType};
 use dns_test::{Network, Result, FQDN};
 
 #[test]
-#[ignore]
 fn rrsig_in_answer_section() -> Result<()> {
     let network = Network::new()?;
 
@@ -33,7 +32,6 @@ fn rrsig_in_answer_section() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn rrsig_in_authority_section() -> Result<()> {
     let network = Network::new()?;
 

--- a/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/packages/dns-test/src/docker/hickory.Dockerfile
@@ -1,15 +1,16 @@
 FROM rust:1-slim-bookworm
 
-# ldns-utils = ldns-{key2ds,keygen,signzone}
+# libssl-dev + pkg-config = required to build hickory-dns with feature dnssec-openssl
 RUN apt-get update && \
     apt-get install -y \
-        ldnsutils \
+        libssl-dev \
+        pkg-config \
         tshark
 
 # `dns-test` will invoke `docker build` from a temporary directory that contains
 # a clone of the hickory repository. `./src` here refers to that clone; not to
 # any directory inside the `dns-test` repository
 COPY ./src /usr/src/hickory
-RUN cargo install --path /usr/src/hickory/bin --features recursor --debug && \
+RUN cargo install --path /usr/src/hickory/bin --features dnssec-openssl,recursor --debug && \
     mkdir /etc/hickory
 env RUST_LOG=debug

--- a/packages/dns-test/src/implementation.rs
+++ b/packages/dns-test/src/implementation.rs
@@ -10,7 +10,9 @@ use crate::FQDN;
 pub enum Config<'a> {
     NameServer {
         origin: &'a FQDN,
+        use_dnssec: bool,
     },
+
     Resolver {
         use_dnssec: bool,
         netmask: &'a str,
@@ -90,7 +92,7 @@ impl Implementation {
                 }
             },
 
-            Config::NameServer { origin } => match self {
+            Config::NameServer { origin, use_dnssec } => match self {
                 Self::Bind => {
                     minijinja::render!(
                         include_str!("templates/named.name-server.conf.jinja"),
@@ -108,7 +110,8 @@ impl Implementation {
                 Self::Hickory(_) => {
                     minijinja::render!(
                         include_str!("templates/hickory.name-server.toml.jinja"),
-                        fqdn => origin.as_str()
+                        fqdn => origin.as_str(),
+                        use_dnssec => use_dnssec
                     )
                 }
             },
@@ -153,6 +156,14 @@ impl Implementation {
                 Role::Resolver => "/tmp/unbound.pid",
             },
         }
+    }
+
+    /// Returns `true` if the implementation is [`Hickory`].
+    ///
+    /// [`Hickory`]: Implementation::Hickory
+    #[must_use]
+    pub fn is_hickory(&self) -> bool {
+        matches!(self, Self::Hickory(..))
     }
 }
 

--- a/packages/dns-test/src/name_server.rs
+++ b/packages/dns-test/src/name_server.rs
@@ -201,6 +201,7 @@ impl NameServer<Stopped> {
         const KSK_BITS: usize = 2048;
         const ALGORITHM: &str = "RSASHA1-NSEC3-SHA1";
 
+        let is_hickory = self.implementation.is_hickory();
         let Self {
             container,
             zone_file,
@@ -214,47 +215,89 @@ impl NameServer<Stopped> {
 
         let zone = zone_file.origin();
 
-        let zsk_keygen =
-            format!("cd {ZONES_DIR} && ldns-keygen -a {ALGORITHM} -b {ZSK_BITS} {zone}");
-        let zsk_filename = container.stdout(&["sh", "-c", &zsk_keygen])?;
-        let zsk_path = format!("{ZONES_DIR}/{zsk_filename}.key");
-        let zsk: zone_file::DNSKEY = container.stdout(&["cat", &zsk_path])?.parse()?;
+        let state = if is_hickory {
+            // automatic on-the-fly signing
 
-        let ksk_keygen =
-            format!("cd {ZONES_DIR} && ldns-keygen -k -a {ALGORITHM} -b {KSK_BITS} {zone}");
-        let ksk_filename = container.stdout(&["sh", "-c", &ksk_keygen])?;
-        let ksk_path = format!("{ZONES_DIR}/{ksk_filename}.key");
-        let ksk: zone_file::DNSKEY = container.stdout(&["cat", &ksk_path])?.parse()?;
+            // generate the ZSK
+            container.status_ok(&[
+                "openssl",
+                "genrsa",
+                "-out",
+                "/tmp/private.pem",
+                &ZSK_BITS.to_string(),
+            ])?;
 
-        // -n = use NSEC3 instead of NSEC
-        // -p = set the opt-out flag on all nsec3 rrs
-        let signzone = format!(
-            "cd {ZONES_DIR} && ldns-signzone -n -p {ZONE_FILENAME} {zsk_filename} {ksk_filename}"
-        );
-        container.status_ok(&["sh", "-c", &signzone])?;
+            // FIXME produce DS and DNSKEY records
+            let ds = DS {
+                zone: zone.clone(),
+                ttl: 0,
+                key_tag: 0,
+                algorithm: 0,
+                digest_type: 0,
+                digest: String::new(),
+            };
+            let zsk = record::DNSKEY {
+                zone: zone.clone(),
+                ttl: 0,
+                flags: 0,
+                protocol: 0,
+                algorithm: 0,
+                public_key: String::new(),
+            };
+            // XXX no KSK in this case?
+            let ksk = zsk.clone();
+            // XXX there's no `signed` zone file in this branch
+            Signed {
+                ds,
+                signed: zone_file.clone(),
+                zsk,
+                ksk,
+            }
+        } else {
+            // manual ahead-of-time signing
+            let zsk_keygen =
+                format!("cd {ZONES_DIR} && ldns-keygen -a {ALGORITHM} -b {ZSK_BITS} {zone}");
+            let zsk_filename = container.stdout(&["sh", "-c", &zsk_keygen])?;
+            let zsk_path = format!("{ZONES_DIR}/{zsk_filename}.key");
+            let zsk: zone_file::DNSKEY = container.stdout(&["cat", &zsk_path])?.parse()?;
 
-        // TODO do we want to make the hashing algorithm configurable?
-        // -2 = use SHA256 for the DS hash
-        let key2ds = format!("cd {ZONES_DIR} && ldns-key2ds -n -2 {ZONE_FILENAME}.signed");
-        let ds: DS = container.stdout(&["sh", "-c", &key2ds])?.parse()?;
+            let ksk_keygen =
+                format!("cd {ZONES_DIR} && ldns-keygen -k -a {ALGORITHM} -b {KSK_BITS} {zone}");
+            let ksk_filename = container.stdout(&["sh", "-c", &ksk_keygen])?;
+            let ksk_path = format!("{ZONES_DIR}/{ksk_filename}.key");
+            let ksk: zone_file::DNSKEY = container.stdout(&["cat", &ksk_path])?.parse()?;
 
-        let signed: ZoneFile = container
-            .stdout(&["cat", &format!("{zone_file_path}.signed")])?
-            .parse()?;
+            // -n = use NSEC3 instead of NSEC
+            // -p = set the opt-out flag on all nsec3 rrs
+            let signzone = format!(
+                "cd {ZONES_DIR} && ldns-signzone -n -p {ZONE_FILENAME} {zsk_filename} {ksk_filename}"
+            );
+            container.status_ok(&["sh", "-c", &signzone])?;
 
-        let ttl = zone_file.soa.ttl;
+            // TODO do we want to make the hashing algorithm configurable?
+            // -2 = use SHA256 for the DS hash
+            let key2ds = format!("cd {ZONES_DIR} && ldns-key2ds -n -2 {ZONE_FILENAME}.signed");
+            let ds: DS = container.stdout(&["sh", "-c", &key2ds])?.parse()?;
 
-        Ok(NameServer {
-            container,
-            implementation,
-            zone_file,
-            state: Signed {
+            let signed: ZoneFile = container
+                .stdout(&["cat", &format!("{zone_file_path}.signed")])?
+                .parse()?;
+
+            let ttl = zone_file.soa.ttl;
+            Signed {
                 ds,
                 signed,
                 // inherit SOA's TTL value
                 ksk: ksk.with_ttl(ttl),
                 zsk: zsk.with_ttl(ttl),
-            },
+            }
+        };
+
+        Ok(NameServer {
+            container,
+            implementation,
+            zone_file,
+            state,
         })
     }
 
@@ -269,6 +312,7 @@ impl NameServer<Stopped> {
 
         let config = Config::NameServer {
             origin: zone_file.origin(),
+            use_dnssec: false,
         };
 
         container.cp(
@@ -314,6 +358,7 @@ impl NameServer<Signed> {
 
         let config = Config::NameServer {
             origin: zone_file.origin(),
+            use_dnssec: true,
         };
         container.cp(
             implementation.conf_file_path(config.role()),

--- a/packages/dns-test/src/record.rs
+++ b/packages/dns-test/src/record.rs
@@ -14,7 +14,7 @@ const CLASS: &str = "IN"; // "internet"
 macro_rules! record_types {
     ($($variant:ident),*) => {
         #[allow(clippy::upper_case_acronyms)]
-        #[derive(Debug, PartialEq)]
+        #[derive(Clone, Debug, PartialEq)]
         pub enum RecordType {
             $($variant),*
         }
@@ -49,7 +49,7 @@ macro_rules! record_types {
 
 record_types!(A, AAAA, DNSKEY, DS, MX, NS, NSEC3, NSEC3PARAM, RRSIG, SOA, TXT);
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Record {
     A(A),
@@ -184,7 +184,7 @@ impl fmt::Display for Record {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct A {
     pub fqdn: FQDN,
     pub ttl: u32,
@@ -327,12 +327,12 @@ impl fmt::Display for DNSKEY {
 
 #[derive(Clone, Debug)]
 pub struct DS {
-    zone: FQDN,
-    ttl: u32,
-    key_tag: u16,
-    algorithm: u8,
-    digest_type: u8,
-    digest: String,
+    pub zone: FQDN,
+    pub ttl: u32,
+    pub key_tag: u16,
+    pub algorithm: u8,
+    pub digest_type: u8,
+    pub digest: String,
 }
 
 impl FromStr for DS {
@@ -387,7 +387,7 @@ impl fmt::Display for DS {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NS {
     pub zone: FQDN,
     pub ttl: u32,
@@ -431,7 +431,7 @@ impl FromStr for NS {
 }
 
 // integer types chosen based on bit sizes in section 3.2 of RFC5155
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NSEC3 {
     pub fqdn: FQDN,
     pub ttl: u32,
@@ -501,7 +501,7 @@ impl fmt::Display for NSEC3 {
 }
 
 // integer types chosen based on bit sizes in section 4.2 of RFC5155
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NSEC3PARAM {
     pub zone: FQDN,
     pub ttl: u32,
@@ -559,7 +559,7 @@ impl fmt::Display for NSEC3PARAM {
 
 // integer types chosen based on bit sizes in section 3.1 of RFC4034
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RRSIG {
     pub fqdn: FQDN,
     pub ttl: u32,
@@ -638,7 +638,7 @@ impl fmt::Display for RRSIG {
 }
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SOA {
     pub zone: FQDN,
     pub ttl: u32,
@@ -696,7 +696,7 @@ impl fmt::Display for SOA {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SoaSettings {
     pub serial: u32,
     pub refresh: u32,

--- a/packages/dns-test/src/templates/hickory.name-server.toml.jinja
+++ b/packages/dns-test/src/templates/hickory.name-server.toml.jinja
@@ -2,3 +2,11 @@
 zone = "{{ fqdn }}"
 zone_type = "Primary"
 file = "/etc/zones/main.zone"
+enable_dnssec = {{ use_dnssec }}
+
+{%if use_dnssec %}
+[[zones.keys]]
+key_path = "/tmp/private.pem"
+algorithm = "RSASHA256"
+is_zone_signing_key = true
+{% endif %}

--- a/packages/dns-test/src/zone_file/mod.rs
+++ b/packages/dns-test/src/zone_file/mod.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use crate::record::{self, Record, SOA};
 use crate::{Error, Result, DEFAULT_TTL, FQDN};
 
+#[derive(Clone)]
 pub struct ZoneFile {
     origin: FQDN,
     pub soa: SOA,


### PR DESCRIPTION
this implementation is super hacky. we should probably add a new type state, e.g. `OnTheFlySigning`, to support
runtime ("on-the-fly") signing of records, which only BIND and hickory implement

:warning:  **NOTE**: this PR depends on #41  so its base branch has been set to that PR's branch. switch the base to `main` before merging this