### PR TITLE
hickory/resolver: drop _cache_size settings

### DIFF
--- a/packages/dns-test/src/templates/hickory.resolver.toml.jinja
+++ b/packages/dns-test/src/templates/hickory.resolver.toml.jinja
@@ -1,5 +1,5 @@
 [[zones]]
 zone = "."
 zone_type = "Hint"
-stores = { type = "recursor", roots = "/etc/root.hints", ns_cache_size = 1024, record_cache_size = 1048576 }
+stores = { type = "recursor", roots = "/etc/root.hints" }
 enable_dnssec = {{ use_dnssec }}


### PR DESCRIPTION
they are not required as default values exist