### PR TITLE
Refactor test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ let com_ns: NameServer;         // for `com.` zone
 let nameservers_ns: NameServer; // for `nameservers.com.` zone
 
 nameservers_ns
-    .add(Record::a(root_ns.fqdn().clone(), root_ns.ipv4_addr()))
-    .add(Record::a(com_ns.fqdn().clone(), com_ns.ipv4_addr()));
+    .add(root_ns.a())
+    .add(com_ns.a());
 
 // each `NameServer` will start out with an A record of its FQDN to its own IPv4 address in its
 // zone file so NO need to add that one in the preceding statement

--- a/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
@@ -5,7 +5,6 @@ use dns_test::{
     name_server::NameServer,
     record::{Record, RecordType},
     tshark::{Capture, Direction},
-    zone_file::Root,
     Network, Resolver, Result, FQDN,
 };
 
@@ -16,8 +15,7 @@ fn do_bit_not_set_in_request() -> Result<()> {
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-        .start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
 
     let mut tshark = resolver.eavesdrop()?;
 
@@ -61,8 +59,7 @@ fn if_do_bit_not_set_in_request_then_requested_dnssec_record_is_not_stripped() -
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-        .start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
 
     let client = Client::new(network)?;
     let settings = *DigSettings::default().recurse();
@@ -88,8 +85,7 @@ fn do_bit_set_in_request() -> Result<()> {
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-        .start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
 
     let mut tshark = resolver.eavesdrop()?;
 

--- a/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2/section_3_2_2.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2/section_3_2_2.rs
@@ -4,7 +4,6 @@ use dns_test::{
     client::{Client, DigSettings},
     name_server::NameServer,
     record::RecordType,
-    zone_file::Root,
     Network, Resolver, Result, FQDN,
 };
 
@@ -14,8 +13,7 @@ use crate::resolver::dnssec::fixtures;
 fn copies_cd_bit_from_query_to_response() -> Result<()> {
     let network = &Network::new()?;
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.start()?;
-    let resolver = Resolver::new(network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-        .start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
 
     let client = Client::new(network)?;
     let settings = *DigSettings::default().checking_disabled().recurse();

--- a/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
@@ -2,7 +2,6 @@ use dns_test::client::{Client, DigSettings};
 use dns_test::name_server::NameServer;
 use dns_test::record::RecordType;
 use dns_test::tshark::{Capture, Direction};
-use dns_test::zone_file::Root;
 use dns_test::{Network, Resolver, Result, FQDN};
 
 #[test]
@@ -10,8 +9,7 @@ use dns_test::{Network, Resolver, Result, FQDN};
 fn edns_support() -> Result<()> {
     let network = &Network::new()?;
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.start()?;
-    let resolver = Resolver::new(network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-        .start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
 
     let mut tshark = resolver.eavesdrop()?;
 

--- a/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -2,7 +2,7 @@ use std::net::Ipv4Addr;
 
 use dns_test::client::{Client, DigSettings};
 use dns_test::name_server::NameServer;
-use dns_test::record::{Record, RecordType};
+use dns_test::record::RecordType;
 use dns_test::zone_file::Root;
 use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 
@@ -14,7 +14,7 @@ use crate::resolver::dnssec::fixtures;
 fn can_validate_without_delegation() -> Result<()> {
     let network = Network::new()?;
     let mut ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, &network)?;
-    ns.add(Record::a(ns.fqdn().clone(), ns.ipv4_addr()));
+    ns.add(ns.a());
     let ns = ns.sign()?;
 
     let root_ksk = ns.key_signing_key().clone();

--- a/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -3,7 +3,6 @@ use std::net::Ipv4Addr;
 use dns_test::client::{Client, DigSettings};
 use dns_test::name_server::NameServer;
 use dns_test::record::RecordType;
-use dns_test::zone_file::Root;
 use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 
 use crate::resolver::dnssec::fixtures;
@@ -27,7 +26,7 @@ fn can_validate_without_delegation() -> Result<()> {
     eprintln!("root.zone:\n{}", ns.zone_file());
 
     let trust_anchor = &TrustAnchor::from_iter([root_ksk.clone(), root_zsk.clone()]);
-    let resolver = Resolver::new(&network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
+    let resolver = Resolver::new(&network, ns.root_hint())
         .trust_anchor(trust_anchor)
         .start(&dns_test::SUBJECT)?;
     let resolver_addr = resolver.ipv4_addr();

--- a/packages/dns-test/examples/explore.rs
+++ b/packages/dns-test/examples/explore.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 
 use dns_test::client::Client;
 use dns_test::name_server::NameServer;
-use dns_test::record::{Record, RecordType};
+use dns_test::record::RecordType;
 use dns_test::zone_file::Root;
 use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 
@@ -22,9 +22,7 @@ fn main() -> Result<()> {
     let mut com_ns = NameServer::new(peer, FQDN::COM, &network)?;
 
     let mut nameservers_ns = NameServer::new(peer, FQDN("nameservers.com.")?, &network)?;
-    nameservers_ns
-        .add(Record::a(root_ns.fqdn().clone(), root_ns.ipv4_addr()))
-        .add(Record::a(com_ns.fqdn().clone(), com_ns.ipv4_addr()));
+    nameservers_ns.add(root_ns.a()).add(com_ns.a());
 
     let nameservers_ns = if args.dnssec {
         let nameservers_ns = nameservers_ns.sign()?;

--- a/packages/dns-test/examples/explore.rs
+++ b/packages/dns-test/examples/explore.rs
@@ -32,11 +32,7 @@ fn main() -> Result<()> {
         nameservers_ns.start()?
     };
 
-    com_ns.referral(
-        nameservers_ns.zone().clone(),
-        nameservers_ns.fqdn().clone(),
-        nameservers_ns.ipv4_addr(),
-    );
+    com_ns.referral_nameserver(&nameservers_ns);
 
     let com_ns = if args.dnssec {
         let com_ns = com_ns.sign()?;
@@ -46,7 +42,7 @@ fn main() -> Result<()> {
         com_ns.start()?
     };
 
-    root_ns.referral(FQDN::COM, com_ns.fqdn().clone(), com_ns.ipv4_addr());
+    root_ns.referral_nameserver(&com_ns);
 
     let mut trust_anchor = TrustAnchor::empty();
     let root_ns = if args.dnssec {

--- a/packages/dns-test/examples/explore.rs
+++ b/packages/dns-test/examples/explore.rs
@@ -5,7 +5,6 @@ use std::sync::mpsc;
 use dns_test::client::Client;
 use dns_test::name_server::NameServer;
 use dns_test::record::RecordType;
-use dns_test::zone_file::Root;
 use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 
 fn main() -> Result<()> {
@@ -74,12 +73,9 @@ fn main() -> Result<()> {
     }
 
     println!("building docker image...");
-    let resolver = Resolver::new(
-        &network,
-        Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr()),
-    )
-    .trust_anchor(&trust_anchor)
-    .start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(&network, root_ns.root_hint())
+        .trust_anchor(&trust_anchor)
+        .start(&dns_test::SUBJECT)?;
     println!("DONE\n\n");
 
     let (tx, rx) = mpsc::channel();

--- a/packages/dns-test/src/name_server.rs
+++ b/packages/dns-test/src/name_server.rs
@@ -71,11 +71,7 @@ impl Graph {
                 unreachable!()
             };
 
-            parent.referral(
-                child.zone().clone(),
-                child.fqdn().clone(),
-                child.ipv4_addr(),
-            );
+            parent.referral_nameserver(child);
         }
 
         let root = nameservers.last().unwrap();
@@ -186,6 +182,15 @@ impl NameServer<Stopped> {
     pub fn referral(&mut self, zone: FQDN, nameserver: FQDN, ipv4_addr: Ipv4Addr) -> &mut Self {
         self.zone_file.referral(zone, nameserver, ipv4_addr);
         self
+    }
+
+    /// Adds a NS + A record pair to the zone file from another NameServer
+    pub fn referral_nameserver<T>(&mut self, nameserver: &NameServer<T>) -> &mut Self {
+        self.referral(
+            nameserver.zone().clone(),
+            nameserver.fqdn().clone(),
+            nameserver.ipv4_addr(),
+        )
     }
 
     /// Adds a record to the name server's zone file

--- a/packages/dns-test/src/name_server.rs
+++ b/packages/dns-test/src/name_server.rs
@@ -419,6 +419,11 @@ impl<S> NameServer<S> {
     pub fn a(&self) -> Record {
         Record::a(self.fqdn().clone(), self.ipv4_addr())
     }
+
+    /// Returns the [`Root`] hint for this server.
+    pub fn root_hint(&self) -> Root {
+        Root::new(self.fqdn().clone(), self.ipv4_addr())
+    }
 }
 
 pub struct Stopped;

--- a/packages/dns-test/src/name_server.rs
+++ b/packages/dns-test/src/name_server.rs
@@ -55,7 +55,7 @@ impl Graph {
                 leaf.container.network(),
             )?;
 
-            leaf.add(Record::a(nameserver.fqdn().clone(), nameserver.ipv4_addr()));
+            leaf.add(nameserver.a());
             nameservers.push(nameserver);
 
             zone = parent;
@@ -408,6 +408,11 @@ impl<S> NameServer<S> {
 
     pub fn fqdn(&self) -> &FQDN {
         &self.zone_file.soa.nameserver
+    }
+
+    /// Returns the [`Record::A`] record for this server.
+    pub fn a(&self) -> Record {
+        Record::a(self.fqdn().clone(), self.ipv4_addr())
     }
 }
 

--- a/packages/dns-test/src/resolver.rs
+++ b/packages/dns-test/src/resolver.rs
@@ -183,8 +183,7 @@ mod tests {
     fn terminate_unbound_works() -> Result<()> {
         let network = Network::new()?;
         let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
-        let resolver = Resolver::new(&network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-            .start(&Implementation::Unbound)?;
+        let resolver = Resolver::new(&network, ns.root_hint()).start(&Implementation::Unbound)?;
         let logs = resolver.terminate()?;
 
         eprintln!("{logs}");
@@ -197,8 +196,7 @@ mod tests {
     fn terminate_bind_works() -> Result<()> {
         let network = Network::new()?;
         let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
-        let resolver = Resolver::new(&network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-            .start(&Implementation::Bind)?;
+        let resolver = Resolver::new(&network, ns.root_hint()).start(&Implementation::Bind)?;
         let logs = resolver.terminate()?;
 
         eprintln!("{logs}");
@@ -211,10 +209,9 @@ mod tests {
     fn terminate_hickory_works() -> Result<()> {
         let network = Network::new()?;
         let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
-        let resolver = Resolver::new(&network, Root::new(ns.fqdn().clone(), ns.ipv4_addr()))
-            .start(&Implementation::Hickory(Repository(
-                "https://github.com/hickory-dns/hickory-dns",
-            )))?;
+        let resolver = Resolver::new(&network, ns.root_hint()).start(&Implementation::Hickory(
+            Repository("https://github.com/hickory-dns/hickory-dns"),
+        ))?;
         let logs = resolver.terminate()?;
 
         // Hickory-DNS start sequence log has been consumed in `ResolverSettings.start`.

--- a/packages/dns-test/src/tshark.rs
+++ b/packages/dns-test/src/tshark.rs
@@ -264,7 +264,7 @@ struct Ip {
 mod tests {
     use crate::client::{Client, DigSettings};
     use crate::name_server::NameServer;
-    use crate::record::{Record, RecordType};
+    use crate::record::RecordType;
     use crate::zone_file::Root;
     use crate::{Implementation, Network, Resolver, FQDN};
 
@@ -313,9 +313,7 @@ mod tests {
 
         let mut nameservers_ns =
             NameServer::new(&Implementation::Unbound, FQDN("nameservers.com.")?, network)?;
-        nameservers_ns
-            .add(Record::a(root_ns.fqdn().clone(), root_ns.ipv4_addr()))
-            .add(Record::a(com_ns.fqdn().clone(), com_ns.ipv4_addr()));
+        nameservers_ns.add(root_ns.a()).add(com_ns.a());
         let nameservers_ns = nameservers_ns.start()?;
 
         com_ns.referral(

--- a/packages/dns-test/src/tshark.rs
+++ b/packages/dns-test/src/tshark.rs
@@ -316,14 +316,10 @@ mod tests {
         nameservers_ns.add(root_ns.a()).add(com_ns.a());
         let nameservers_ns = nameservers_ns.start()?;
 
-        com_ns.referral(
-            nameservers_ns.zone().clone(),
-            nameservers_ns.fqdn().clone(),
-            nameservers_ns.ipv4_addr(),
-        );
+        com_ns.referral_nameserver(&nameservers_ns);
         let com_ns = com_ns.start()?;
 
-        root_ns.referral(FQDN::COM, com_ns.fqdn().clone(), com_ns.ipv4_addr());
+        root_ns.referral_nameserver(&com_ns);
         let root_ns = root_ns.start()?;
 
         let resolver = Resolver::new(

--- a/packages/dns-test/src/tshark.rs
+++ b/packages/dns-test/src/tshark.rs
@@ -265,7 +265,6 @@ mod tests {
     use crate::client::{Client, DigSettings};
     use crate::name_server::NameServer;
     use crate::record::RecordType;
-    use crate::zone_file::Root;
     use crate::{Implementation, Network, Resolver, FQDN};
 
     use super::*;
@@ -322,11 +321,8 @@ mod tests {
         root_ns.referral_nameserver(&com_ns);
         let root_ns = root_ns.start()?;
 
-        let resolver = Resolver::new(
-            network,
-            Root::new(root_ns.fqdn().clone(), root_ns.ipv4_addr()),
-        )
-        .start(&Implementation::Unbound)?;
+        let resolver =
+            Resolver::new(network, root_ns.root_hint()).start(&Implementation::Unbound)?;
         let mut tshark = resolver.eavesdrop()?;
         let resolver_addr = resolver.ipv4_addr();
 


### PR DESCRIPTION
This PR refactors a few small things to hopefully improve readability of the tests somewhat.

Often a pair of `fqdn` & `ipv4_addr` for a given name server are used to set up `A` records, therefore a method in `NameServer` can be used instead to produce this record. Similar the root hint can be returned from a `NameServer`.

* add another referral method to link name servers