### PR TITLE
Check hickory-dns is fully started

### DIFF
--- a/packages/dns-test/src/implementation.rs
+++ b/packages/dns-test/src/implementation.rs
@@ -55,6 +55,11 @@ impl Implementation {
         matches!(self, Self::Bind)
     }
 
+    #[must_use]
+    pub fn is_hickory(&self) -> bool {
+        matches!(self, Self::Hickory(_))
+    }
+
     pub(crate) fn format_config(&self, config: Config) -> String {
         match config {
             Config::Resolver {


### PR DESCRIPTION
When starting `hickory-dns` there is no easy way to check that its start sequence has finished & is ready to accept connections. Other tools, e.g. unbound, are designed as services, they will correctly manage their `pidfile`. They also can be queried by the `servicectl` inside the Docker container, given the right service name.

**Note** hickory-dns does not make use of a `pidfile` yet. Their [README](https://github.com/hickory-dns/hickory-dns?tab=readme-ov-file#hickory-dns) states that the server can be run as a daemon, but it lacks sufficient support for it.

This PR therefore checks & consumes the output on `stdout` until the appropriate string appears that signals the server has started successfully.